### PR TITLE
Update optimise.js

### DIFF
--- a/optimise.js
+++ b/optimise.js
@@ -22,10 +22,10 @@ module.exports = function optimise(name, content, opts) {
     new Promise((res, rej) => {
       svgo.optimize(content).then(res, rej);
     });
-  const optimizeSync = deasync(optimize);
+ // const optimizeSync = deasync(optimize);
 
   try {
-    let { data: output } = optimizeSync(content);
+     let output = content;
 
     ids.forEach(id => {
       const r = makeRegex(id);


### PR DESCRIPTION
timeout error occurs on inclusion.
typically repro in jest or build process since promise doesn't resolve
and there's really no need for the forced sync