### PR TITLE
Unify transformer arguments & compose them

### DIFF
--- a/lib/babel-plugin-inline-svg.js
+++ b/lib/babel-plugin-inline-svg.js
@@ -46,7 +46,7 @@ module.exports = ({ types }) => ({
 
         const sauce = disableNamespaceIds
           ? maybeOptimized
-          : namespaceIds(varName, maybeOptimized);
+          : namespaceIds(maybeOptimized, varName);
 
         const svgReplacement = buildOutput({
           SVG_NAME: importIdentifier,

--- a/lib/babel-plugin-inline-svg.js
+++ b/lib/babel-plugin-inline-svg.js
@@ -10,6 +10,11 @@ const buildOutput = template(`
   var SVG_NAME = SVG_CODE;
 `);
 
+const noop = (a) => a;
+const compose = (...fns) => (arg) =>
+  fns.reduceRight((acc, fn) => (fn ? fn(acc) : acc), arg);
+const curry = (fn) => (opts) => (input) => fn(input, opts);
+
 let ignoreRegex;
 
 module.exports = ({ types }) => ({
@@ -35,22 +40,19 @@ module.exports = ({ types }) => ({
       if (extname(path.node.source.value) === ".svg") {
         // We only support the import default specifier, so let's use that identifier:
         const importIdentifier = path.node.specifiers[0].local;
+        const varName = importIdentifier.name;
         const iconPath = state.file.opts.filename;
         const svgPath = resolveFrom(dirname(iconPath), path.node.source.value);
-        const rawSource = readFileSync(svgPath, "utf8");
-        const varName = importIdentifier.name;
+        const input = readFileSync(svgPath, "utf8");
 
-        const maybeOptimized = disableSVGO
-          ? rawSource
-          : optimize(rawSource, state.opts.svgo);
-
-        const sauce = disableNamespaceIds
-          ? maybeOptimized
-          : namespaceIds(maybeOptimized, varName);
+        const output = compose(
+          disableNamespaceIds ? noop : curry(namespaceIds)(varName),
+          disableSVGO ? noop : curry(optimize)(state.opts.svgo)
+        )(input);
 
         const svgReplacement = buildOutput({
           SVG_NAME: importIdentifier,
-          SVG_CODE: types.stringLiteral(sauce),
+          SVG_CODE: types.stringLiteral(output),
         });
 
         path.replaceWith(svgReplacement);

--- a/lib/namespace-ids.js
+++ b/lib/namespace-ids.js
@@ -6,9 +6,9 @@ const idDefRegex = makeDefinitionRegex(".*?");
 const getIds = (str) =>
   (str.match(idDefRegex) || []).map((s) => s.replace(idDefRegex, "$1"));
 
-function namespaceIds(name, content) {
-  const ids = getIds(content);
-  let output = content;
+function namespaceIds(input, name) {
+  const ids = getIds(input);
+  let output = input;
 
   ids.forEach((id) => {
     const defRegex = makeDefinitionRegex(id);


### PR DESCRIPTION
- [x] Make `optimize` and `namespaceIds` functions (transformers) use the same `(content, options)` argument order
- [x] Use function currying and composition to simplify transformation of output

This should make it easier to add further transformation functions as needed, instead of creating new variable names each time we transform the output...